### PR TITLE
Added BatchRepeater

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ Awesome burp extensions is an amazing list for people who want to spice up their
 * [CookieMonster](https://github.com/baegmon/CookieMonster) -  A Burp Suite plugin to easily manage cookies 
 * [SocketSleuth](https://github.com/snyk/socketsleuth) - Burp Extension to add additional functionality for pentesting websocket based applications 
 * [DNS-Exfilnspector](https://github.com/LazyTitan33/DNS-Exfilnspector) - Automagically decode DNS Exfiltration queries to convert Blind RCE into proper RCE via Burp Collaborator
+* [BatchRepeater](https://github.com/Mathemag1cian/BatchRepeater) - BatchRepeater is a BurpSuite extension that enhances the functionality of the Repeater tool by allowing users to send multiple selected HTTP requests to the Repeater in a single action.
 
 ## Beautifiers and Decoders
 


### PR DESCRIPTION
Added BatchRepeater - https://github.com/Mathemag1cian/BatchRepeater

BatchRepeater is a BurpSuite extension that enhances the functionality of the Repeater tool by allowing users to send multiple selected HTTP requests to the Repeater in a single action.